### PR TITLE
Update org.gnome.Platform to 41 & drop gtk4 dep

### DIFF
--- a/com.belmoussaoui.Obfuscate.json
+++ b/com.belmoussaoui.Obfuscate.json
@@ -55,8 +55,8 @@
             "sources": [{
                 "type": "git",
                 "url": "https://gitlab.gnome.org/GNOME/libadwaita.git",
-                "branch": "main",
-                "commit": "3aa34feae01ebac9492ff46eb9c00a500934895d"
+                "tag": "1.0.0-alpha.2",
+                "commit": "f5932ab4250c8e709958c6e75a1a4941a5f0f386"
             }]
         },
         {

--- a/com.belmoussaoui.Obfuscate.json
+++ b/com.belmoussaoui.Obfuscate.json
@@ -39,20 +39,6 @@
             }]
         },
         {
-            "name": "gtk4",
-            "buildsystem": "meson",
-            "config-opts": [
-                "-Ddemos=false",
-                "-Dbuild-examples=false",
-                "-Dbuild-tests=false"
-            ],
-            "sources": [{
-                "type": "git",
-                "url": "https://gitlab.gnome.org/GNOME/gtk.git",
-                "commit": "67952a91420bc6230eac7f68700b38595322813f"
-            }]
-        },
-        {
             "name": "libadwaita",
             "buildsystem": "meson",
             "config-opts": [

--- a/com.belmoussaoui.Obfuscate.json
+++ b/com.belmoussaoui.Obfuscate.json
@@ -1,7 +1,7 @@
 {
     "app-id": "com.belmoussaoui.Obfuscate",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "40",
+    "runtime-version" : "41",
     "sdk" : "org.gnome.Sdk",
     "sdk-extensions" : [
         "org.freedesktop.Sdk.Extension.rust-stable"


### PR DESCRIPTION
We can drop `gtk4` dep now with new runtime. Also works correctly with `libadwaita 1.0.0-alpha.2` version. Tested this build and LGTM.